### PR TITLE
torch.cuda("cpu") --> torch.device("cpu")

### DIFF
--- a/docs/tutorial_notebooks/tutorial7/GNN_overview.ipynb
+++ b/docs/tutorial_notebooks/tutorial7/GNN_overview.ipynb
@@ -97,7 +97,7 @@
     "torch.backends.cudnn.determinstic = True\n",
     "torch.backends.cudnn.benchmark = False\n",
     "\n",
-    "device = torch.device(\"cuda:0\") if torch.cuda.is_available() else torch.cuda(\"cpu\")\n",
+    "device = torch.device(\"cuda:0\") if torch.cuda.is_available() else torch.device(\"cpu\")\n",
     "print(device)"
    ]
   },


### PR DESCRIPTION
Minor edit. I think this will prevent CPU users from getting the error `'module' object is not callable` :)