### PR TITLE
Add missing dependencies to conda environments

### DIFF
--- a/dl2021_cpu.yml
+++ b/dl2021_cpu.yml
@@ -19,3 +19,4 @@ dependencies:
     - notebook==6.4.5
     - jupyterlab==3.2.1
     - matplotlib==3.4.3
+    - seaborn==0.11.2

--- a/dl2021_cpu.yml
+++ b/dl2021_cpu.yml
@@ -18,3 +18,4 @@ dependencies:
     - pillow==8.0.1
     - notebook==6.4.5
     - jupyterlab==3.2.1
+    - matplotlib==3.4.3

--- a/dl2021_cpu.yml
+++ b/dl2021_cpu.yml
@@ -16,3 +16,5 @@ dependencies:
     - tabulate==0.8.9
     - tqdm==4.62.3
     - pillow==8.0.1
+    - notebook==6.4.5
+    - jupyterlab==3.2.1

--- a/dl2021_cpu.yml
+++ b/dl2021_cpu.yml
@@ -20,3 +20,4 @@ dependencies:
     - jupyterlab==3.2.1
     - matplotlib==3.4.3
     - seaborn==0.11.2
+    - ipywidgets==7.6.5

--- a/dl2021_gpu.yml
+++ b/dl2021_gpu.yml
@@ -19,3 +19,4 @@ dependencies:
     - notebook==6.4.5
     - jupyterlab==3.2.1
     - matplotlib==3.4.3
+    - seaborn==0.11.2

--- a/dl2021_gpu.yml
+++ b/dl2021_gpu.yml
@@ -18,3 +18,4 @@ dependencies:
     - pillow==8.0.1
     - notebook==6.4.5
     - jupyterlab==3.2.1
+    - matplotlib==3.4.3

--- a/dl2021_gpu.yml
+++ b/dl2021_gpu.yml
@@ -16,3 +16,5 @@ dependencies:
     - tabulate==0.8.9
     - tqdm==4.62.3
     - pillow==8.0.1
+    - notebook==6.4.5
+    - jupyterlab==3.2.1

--- a/dl2021_gpu.yml
+++ b/dl2021_gpu.yml
@@ -20,3 +20,4 @@ dependencies:
     - jupyterlab==3.2.1
     - matplotlib==3.4.3
     - seaborn==0.11.2
+    - ipywidgets==7.6.5


### PR DESCRIPTION
The conda environment files were missing installation instructions for `matplotlib` and `seaborn` which are used in tutorial 2. They were also missing any jupyter installation (e.g. lab or notebook). Of course, users can install these themselves with pip, but it would be nicer if setting up the conda environment was enough to get started. 

This PR adds these dependencies to the conda environments.