### PR TITLE
Typo for CDF of gumbel distribution.

### DIFF
--- a/docs/tutorial_notebooks/DL2/sampling/introduction.ipynb
+++ b/docs/tutorial_notebooks/DL2/sampling/introduction.ipynb
@@ -38,7 +38,7 @@
     "Sample $U_k \\sim Uniform(0,1)$ iid and compute $r_k = \\log\\alpha_k -log(-\\log U_k)$. Then choose the index $i$ of the maximum $r_k$ (ie take the argmax) and return the 1-hot vector with the $i$th index set to 1 and the rest to 0.\n",
     "The form of noise $-log(-\\log U_k)$ added to form $r_k$ has a Gumbel distribution whence the method gets its name. The cumulative distribution function of the Gumbel distribution (with location 0 and scale 1) is given as\n",
     "\n",
-    "$$F(z) = \\exp(\\exp(-z))$$\n",
+    "$$F(z) = \\exp(-\\exp(-z))$$\n",
     "\n",
     "You can take a look at a proof that this indeed samples from the softmax distribution [here](https://lips.cs.princeton.edu/the-gumbel-max-trick-for-discrete-distributions/).\n",
     "\n",


### PR DESCRIPTION
## Tutorial/Bug description
Missing negative sign in CDF of Gumbel distribution formular.

