### PR TITLE
Neural Relation Inference tutorial download link fix

### DIFF
--- a/docs/tutorial_notebooks/DL2/sampling/graphs.ipynb
+++ b/docs/tutorial_notebooks/DL2/sampling/graphs.ipynb
@@ -2,6 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "c0dc626d",
    "metadata": {},
    "source": [
     "# SGA - Graph Sampling for Neural Relational Inference\n",
@@ -53,6 +54,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "3c8ae84f",
    "metadata": {},
    "source": [
     "## Neural Relational Inference\n",
@@ -66,34 +68,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
+   "id": "f64c021a",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "--2022-04-22 15:03:29--  https://surfdrive.surf.nl/files/index.php/s/6YWMO1eiVXI4EkB/download\n",
+      "--2022-06-21 17:04:34--  https://surfdrive.surf.nl/files/index.php/s/LXV9iJjxfu5jhdD/download\n",
       "Resolving surfdrive.surf.nl (surfdrive.surf.nl)... 145.100.27.67, 2001:610:108:203b:0:a11:da7a:5afe\n",
       "Connecting to surfdrive.surf.nl (surfdrive.surf.nl)|145.100.27.67|:443... connected.\n",
       "HTTP request sent, awaiting response... 200 OK\n",
       "Length: 586393709 (559M) [application/zip]\n",
       "Saving to: ‘nri_springs.zip’\n",
       "\n",
-      "100%[======================================>] 586,393,709  113MB/s   in 5.1s   \n",
+      "100%[======================================>] 586,393,709 21.9MB/s   in 21s    \n",
       "\n",
-      "2022-04-22 15:03:35 (109 MB/s) - ‘nri_springs.zip’ saved [586393709/586393709]\n",
+      "2022-06-21 17:04:55 (26.1 MB/s) - ‘nri_springs.zip’ saved [586393709/586393709]\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "!wget -O 'nri_springs.zip' https://surfdrive.surf.nl/files/index.php/s/6YWMO1eiVXI4EkB/download\n"
+    "!wget -O 'nri_springs.zip' https://surfdrive.surf.nl/files/index.php/s/LXV9iJjxfu5jhdD/download"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "id": "b953f7a0",
    "metadata": {},
    "outputs": [
     {
@@ -111,6 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
+   "id": "7bf5d23c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,6 +154,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "459179a2",
    "metadata": {},
    "source": [
     "### Loading and Exmaining Data\n",
@@ -159,6 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
+   "id": "7eca925a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,6 +247,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1dac69c5",
    "metadata": {},
    "source": [
     "We specify the batch size and the data file suffix to load."
@@ -248,6 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
+   "id": "d8734701",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,6 +265,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "e6d5b910",
    "metadata": {},
    "source": [
     "Let's now examine this data. We get an iterator from the data loader and retrieve the first minibatch.\n",
@@ -265,6 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
+   "id": "456d6bc9",
    "metadata": {},
    "outputs": [
     {
@@ -284,6 +295,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "1c30fe6c",
    "metadata": {},
    "source": [
     "Let's look at the interaction graph first.\n",
@@ -295,6 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
+   "id": "364a10e8",
    "metadata": {},
    "outputs": [
     {
@@ -312,6 +325,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7584bfb2",
    "metadata": {},
    "source": [
     "This interaction is in the form of a list of interactions pairs. We can convert one such list to an interaction graph adjancency matrix as follows. \n",
@@ -321,6 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
+   "id": "8bf19fce",
    "metadata": {},
    "outputs": [
     {
@@ -347,6 +362,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "f5fea0e6",
    "metadata": {},
    "source": [
     "We can draw the graph"
@@ -355,6 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
+   "id": "7fae7e71",
    "metadata": {},
    "outputs": [
     {
@@ -379,6 +396,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a215e173",
    "metadata": {},
    "source": [
     "Let's now examine the trajectory data for the first data point."
@@ -387,6 +405,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
+   "id": "d37ca7e3",
    "metadata": {},
    "outputs": [
     {
@@ -406,6 +425,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d21e7421",
    "metadata": {},
    "source": [
     "The shape of the data above specifies that each entry consists of 5 particles with trajectories given for 49 time steps.\n",
@@ -417,6 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
+   "id": "6f96d6da",
    "metadata": {},
    "outputs": [
     {
@@ -437,6 +458,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "95face46",
    "metadata": {},
    "source": [
     "Next we define some hyperparameters."
@@ -445,6 +467,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
+   "id": "5727a5a7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,6 +483,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0b79b802",
    "metadata": {},
    "source": [
     "Recall that we mentioned above that the encoder of the model works on the fully connected graph in order to predict the interaction graph.\n",
@@ -469,6 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": 13,
+   "id": "557f2431",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,6 +515,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ccafe778",
    "metadata": {},
    "source": [
     "We can convert edge features into node features and node features into edge features by passing messages over the fully connected graph using these masks."
@@ -498,6 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": 14,
+   "id": "30d57816",
    "metadata": {},
    "outputs": [
     {
@@ -523,6 +550,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "17edda12",
    "metadata": {},
    "source": [
     "For example to convert edge features for the 20 interactions into node features we can multiply the above matrix with the edge feature vector as \n",
@@ -534,6 +562,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d67c17ac",
    "metadata": {},
    "source": [
     "Next we define a simple MLP class to be used for the nonlinear feature transformations."
@@ -542,6 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": 15,
+   "id": "08eb2ce3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -581,6 +611,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "32b842d1",
    "metadata": {},
    "source": [
     "### Encoder\n",
@@ -594,6 +625,7 @@
   {
    "cell_type": "code",
    "execution_count": 16,
+   "id": "6cc6a854",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,6 +682,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "09a2ba91",
    "metadata": {},
    "source": [
     "### Decoder \n",
@@ -664,6 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": 17,
+   "id": "f7dafce3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,6 +797,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a4a2ab0c",
    "metadata": {},
    "source": [
     "Now we make a few helper arrays to specify the sending and receiving nodes in a message passing step. These simply correspond to the neighbors in a fully connected graph."
@@ -771,6 +806,7 @@
   {
    "cell_type": "code",
    "execution_count": 18,
+   "id": "cddffec2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,6 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": 19,
+   "id": "a9731964",
    "metadata": {},
    "outputs": [
     {
@@ -818,6 +855,7 @@
   {
    "cell_type": "code",
    "execution_count": 20,
+   "id": "bc787ac3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,6 +868,7 @@
   {
    "cell_type": "code",
    "execution_count": 21,
+   "id": "96e56e62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,6 +880,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "49dd9b19",
    "metadata": {},
    "source": [
     "### Discrete Sampling\n",
@@ -852,6 +892,7 @@
   {
    "cell_type": "code",
    "execution_count": 22,
+   "id": "3c6e4e05",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -889,6 +930,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "87da1182",
    "metadata": {},
    "source": [
     "Next we define some helper functions for computing accuracies, prediction loss and KL divergence."
@@ -897,6 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": 23,
+   "id": "0c6f0ef6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -927,6 +970,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "cc8129fa",
    "metadata": {},
    "source": [
     "We can now train the model.\n",
@@ -937,6 +981,7 @@
   {
    "cell_type": "code",
    "execution_count": 24,
+   "id": "8bf93b5f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1029,6 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": 25,
+   "id": "51fc52f6",
    "metadata": {},
    "outputs": [
     {
@@ -1069,6 +1115,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "362f4d83",
    "metadata": {},
    "source": [
     "### Visualizing Discovered Graphs\n",
@@ -1078,6 +1125,7 @@
   {
    "cell_type": "code",
    "execution_count": 26,
+   "id": "54827039",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1089,6 +1137,7 @@
   {
    "cell_type": "code",
    "execution_count": 27,
+   "id": "6da19797",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1099,6 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": 28,
+   "id": "f7ca1310",
    "metadata": {},
    "outputs": [
     {
@@ -1120,6 +1170,7 @@
   {
    "cell_type": "code",
    "execution_count": 29,
+   "id": "0beaf74c",
    "metadata": {},
    "outputs": [
     {
@@ -1306,6 +1357,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "23442bce",
    "metadata": {},
    "source": [
     "## References\n",
@@ -1330,7 +1382,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.9"
+   "version": "3.7.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Tutorial/Bug description
<!-- If you add a new tutorial, describe the new tutorial you want to push to the repository. What topic is it dealing with? Which lecture is it relating to? -->
<!-- If you want to fix a bug, describe the bug and how you attempt to fix it. -->
Updated broken dataset download link from the Neural Relational Inference tutorial to https://surfdrive.surf.nl/files/index.php/s/LXV9iJjxfu5jhdD/download.

## Checklist
- [ ] All packages are in the conda environment `dl2021`
- [ ] Pretrained models are automatically downloaded and stored at https://github.com/phlippe/saved_models / a pull request has been setup for this
- [ ] Notebook has badges for:
	- [ ] Filled notebook on github
	- [ ] Filled notebook on Colab
	- [ ] Saved models on github
	- [ ] YouTube recording
- [ ] The author names have been filled in
- [ ] The notebook has been added to the doc tree (`docs/index.rst`)
- [ ] All images of the notebook are included in the pull request
- [ ] The website was build locally once (do not commit the html files)

### How Has This Been Tested?
<!-- Make sure to have tested this notebook at least once for the conda environment, and once on GoogleColab -->
<!-- Further, the tutorial needs to be executable for both CPU and GPU systems -->
- [ ] Conda environment `dl2021`
- [ ] Local computer - CPU
- [ ] Local computer - GPU
- [ ] Google Colab - CPU
- [ ] Google Colab - GPU
- [ ] Lisa - GPU
