### PR TITLE
On tutorial 6 - correct assert condition in function expand_mask(mask)

### DIFF
--- a/docs/tutorial_notebooks/tutorial6/Transformers_and_MHAttention.ipynb
+++ b/docs/tutorial_notebooks/tutorial6/Transformers_and_MHAttention.ipynb
@@ -338,7 +338,7 @@
     "# If 3D: broadcasted over number of heads\n",
     "# If 4D: leave as is\n",
     "def expand_mask(mask):\n",
-    "    assert mask.ndim > 2, \"Mask must be at least 2-dimensional with seq_length x seq_length\"\n",
+    "    assert mask.ndim >= 2, \"Mask must be at least 2-dimensional with seq_length x seq_length\"\n",
     "    if mask.ndim == 3:\n",
     "        mask = mask.unsqueeze(1)\n",
     "    while mask.ndim < 4:\n",


### PR DESCRIPTION

The assertion on expand_mask(mask) was not in line with the message:

`assert mask.ndim > 2, "Mask must be at least 2-dimensional with seq_length x seq_length"`

Changed to 

`assert mask.ndim >= 2, "Mask must be at least 2-dimensional with seq_length x seq_length"`