### PR TITLE
fix: migrate checkpoint code to orbax StandardCheckpointer

### DIFF
--- a/dl2023_jax_gpu.yml
+++ b/dl2023_jax_gpu.yml
@@ -9,7 +9,7 @@ dependencies:
   - pip=22.2.2
   - pytorch-cuda=11.7
   - pytorch=1.13.0
-  - jax=0.4.5
+  - jax>=0.4.25
   - jaxlib[build=*cuda*]
   - cuda-nvcc
   - torchvision=0.14.0
@@ -18,8 +18,9 @@ dependencies:
     - pytorch-lightning==1.7.7
     - tensorboard==2.11.2
     - tensorflow==2.11.0
-    - optax==0.1.4
-    - flax==0.6.6
+    - optax>=0.2.0
+    - flax>=0.7.5
+    - orbax-checkpoint>=0.4.0
     - tabulate>=0.8.9
     - tqdm>=4.62.3
     - pillow>=8.0.1

--- a/docs/tutorial_notebooks/JAX/tutorial2/Introduction_to_JAX.ipynb
+++ b/docs/tutorial_notebooks/JAX/tutorial2/Introduction_to_JAX.ipynb
@@ -176,7 +176,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of a simple NumPy array, it shows the type `DeviceArray` which is what JAX uses to represent arrays. In contrast to NumPy, JAX can execute the same code on different backends – CPU, GPU and TPU. A `DeviceArray` therefore represents an array which is on one of the backends. Similar to PyTorch, we can check the device of an array by calling `.device()`:"
+    "Instead of a simple NumPy array, it shows the type `DeviceArray` which is what JAX uses to represent arrays. In contrast to NumPy, JAX can execute the same code on different backends \u2013 CPU, GPU and TPU. A `DeviceArray` therefore represents an array which is on one of the backends. Similar to PyTorch, we can check the device of an array by calling `.device()`:"
    ]
   },
   {
@@ -446,7 +446,7 @@
     "\n",
     "Rosalia Schneider and Vladimir Mikulik summarize the key points of JAX in the [JAX 101 tutorial](https://jax.readthedocs.io/en/latest/jax-101/01-jax-basics.html) as follows: \n",
     "\n",
-    "> The most important difference, and in some sense the root of all the rest, is that JAX is designed to be functional, as in functional programming. The reason behind this is that the kinds of program transformations that JAX enables are much more feasible in functional-style programs. [...] The important feature of functional programming to grok when working with JAX is very simple: don’t write code with side-effects.\n",
+    "> The most important difference, and in some sense the root of all the rest, is that JAX is designed to be functional, as in functional programming. The reason behind this is that the kinds of program transformations that JAX enables are much more feasible in functional-style programs. [...] The important feature of functional programming to grok when working with JAX is very simple: don\u2019t write code with side-effects.\n",
     "\n",
     "Essentially, we want to write our main code of JAX in functions that do not affect anything else besides its outputs. For instance, we do not want to change input arrays in-place, or access global variables. While this might seem limiting at first, you get used to this quite quickly and most JAX functions that need to fulfill these constraints can be written this way without problems. Note that not all possible functions in training a neural network need to fulfill the constraints. For instance, loading or saving of models, the logging, or the data generation can be done in naive functions. Only the network execution, which we want to do very efficiently on our accelerator (GPU or TPU), should strictly follow these constraints.\n",
     "\n",
@@ -760,7 +760,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "598 µs ± 104 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "598 \u00b5s \u00b1 104 \u00b5s per loop (mean \u00b1 std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -778,7 +778,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19.5 µs ± 52.8 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)\n"
+      "19.5 \u00b5s \u00b1 52.8 ns per loop (mean \u00b1 std. dev. of 7 runs, 100000 loops each)\n"
      ]
     }
    ],
@@ -820,7 +820,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.55 ms ± 190 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+      "2.55 ms \u00b1 190 \u00b5s per loop (mean \u00b1 std. dev. of 7 runs, 1 loop each)\n"
      ]
     }
    ],
@@ -838,7 +838,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "17.4 µs ± 60.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)\n"
+      "17.4 \u00b5s \u00b1 60.6 ns per loop (mean \u00b1 std. dev. of 7 runs, 100000 loops each)\n"
      ]
     }
    ],
@@ -1479,7 +1479,7 @@
        "\" style=\"fill:none;stroke:#ffffff;stroke-linecap:round;\"/>\n",
        "     </g>\n",
        "     <g id=\"text_5\">\n",
-       "      <!-- −0.2 -->\n",
+       "      <!-- \u22120.2 -->\n",
        "      <g style=\"fill:#262626;\" transform=\"translate(22.174375 233.928036)scale(0.11 -0.11)\">\n",
        "       <defs>\n",
        "        <path d=\"M 52.828125 31.203125 \n",
@@ -2698,16 +2698,17 @@
    "source": [
     "#### Saving a model\n",
     "\n",
-    "After we finished training a model, we save the model to disk so that we can load the same weights at a later time. In JAX, this means we want to save the `state.params` dictionary. Luckily, the `flax.training` package again provides us with nice utilities for that, which uses TensorFlow as underlying framework."
+    "After we finished training a model, we save the model to disk so that we can load the same weights at a later time. In JAX, this means we want to save the `state.params` dictionary. Flax integrates with [Orbax](https://github.com/google/orbax) for checkpointing \u2014 we use `orbax.checkpoint.StandardCheckpointer` to save and restore the model state."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from flax.training import checkpoints"
+    "import shutil, pathlib\n",
+    "import orbax.checkpoint as ocp"
    ]
   },
   {
@@ -2719,47 +2720,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'my_checkpoints/my_model100'"
-      ]
-     },
-     "execution_count": 53,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "checkpoints.save_checkpoint(ckpt_dir='my_checkpoints/',  # Folder to save checkpoint in\n",
-    "                            target=trained_model_state,  # What to save. To only save parameters, use model_state.params\n",
-    "                            step=100,  # Training step or other metric to save best model on\n",
-    "                            prefix='my_model',  # Checkpoint file name prefix\n",
-    "                            overwrite=True   # Overwrite existing checkpoint files\n",
-    "                           )"
+    "ckpt_dir = pathlib.Path('/tmp/my_checkpoints/my_model100').absolute()\n",
+    "if ckpt_dir.exists():  # StandardCheckpointer.save errors if the directory already exists\n",
+    "    shutil.rmtree(ckpt_dir)\n",
+    "\n",
+    "checkpointer = ocp.StandardCheckpointer()\n",
+    "checkpointer.save(ckpt_dir, trained_model_state)  # To only save parameters, pass trained_model_state.params"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To load this state dict again, we can use `checkpoints.restore_checkpoint`:"
+    "To load this state dict again, we pass a matching template pytree (here, the freshly-initialized `model_state`) to `StandardCheckpointer.restore`:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "loaded_model_state = checkpoints.restore_checkpoint(\n",
-    "                                             ckpt_dir='my_checkpoints/',   # Folder with the checkpoints\n",
-    "                                             target=model_state,   # (optional) matching object to rebuild state in\n",
-    "                                             prefix='my_model'  # Checkpoint file name prefix\n",
-    "                                            )"
+    "loaded_model_state = checkpointer.restore(ckpt_dir, model_state)  # second arg is the target/template pytree"
    ]
   },
   {
@@ -2962,7 +2948,7 @@
        "   <g id=\"matplotlib.axis_1\">\n",
        "    <g id=\"xtick_1\">\n",
        "     <g id=\"text_1\">\n",
-       "      <!-- −0.5 -->\n",
+       "      <!-- \u22120.5 -->\n",
        "      <g style=\"fill:#262626;\" transform=\"translate(48.64875 256.602969)scale(0.11 -0.11)\">\n",
        "       <defs>\n",
        "        <path d=\"M 52.828125 31.203125 \n",
@@ -3128,7 +3114,7 @@
        "   <g id=\"matplotlib.axis_2\">\n",
        "    <g id=\"ytick_1\">\n",
        "     <g id=\"text_7\">\n",
-       "      <!-- −0.50 -->\n",
+       "      <!-- \u22120.50 -->\n",
        "      <g style=\"fill:#262626;\" transform=\"translate(22.174375 243.166172)scale(0.11 -0.11)\">\n",
        "       <use xlink:href=\"#ArialMT-8722\"/>\n",
        "       <use x=\"58.398438\" xlink:href=\"#ArialMT-48\"/>\n",
@@ -3140,7 +3126,7 @@
        "    </g>\n",
        "    <g id=\"ytick_2\">\n",
        "     <g id=\"text_8\">\n",
-       "      <!-- −0.25 -->\n",
+       "      <!-- \u22120.25 -->\n",
        "      <g style=\"fill:#262626;\" transform=\"translate(22.174375 215.986172)scale(0.11 -0.11)\">\n",
        "       <defs>\n",
        "        <path d=\"M 50.34375 8.453125 \n",
@@ -3944,9 +3930,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## ✨ The Fancy Bits ✨\n",
+    "## \u2728 The Fancy Bits \u2728\n",
     "\n",
-    "After reading this tutorial, you might wonder why we left out some key advertisement points of JAX: automatic vectorization, easy parallelization on multiple accelerators, etc. The reason why we did not include them in our previous discuss is that for building simple networks, and actual most models in our tutorials, you do not really need these methods. However, since they can be handy at some times, for instance, if you have access to a large cluster or are faced with functions that are annoying to vectorize, we review them here in a separate section: the Fancy Bits of JAX (the title is inspired by JAX's tutorial [🔪 JAX - The Sharp Bits 🔪](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html))."
+    "After reading this tutorial, you might wonder why we left out some key advertisement points of JAX: automatic vectorization, easy parallelization on multiple accelerators, etc. The reason why we did not include them in our previous discuss is that for building simple networks, and actual most models in our tutorials, you do not really need these methods. However, since they can be handy at some times, for instance, if you have access to a large cluster or are faced with functions that are annoying to vectorize, we review them here in a separate section: the Fancy Bits of JAX (the title is inspired by JAX's tutorial [\ud83d\udd2a JAX - The Sharp Bits \ud83d\udd2a](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html))."
    ]
   },
   {
@@ -4144,9 +4130,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 🔪 The Sharp Bits 🔪\n",
+    "## \ud83d\udd2a The Sharp Bits \ud83d\udd2a\n",
     "\n",
-    "Since JAX functions need to be written with certain constraints, there are situations where this can get annoying or difficult. A great overview of those, why they are needed, and most importantly, what to do about them, can be found in the original JAX tutorial [🔪 JAX - The Sharp Bits 🔪](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html). In this final section of the tutorial, we want to visit a few of those points we have not explicitly discussed yet. Furthermore, we also focus on the combination with Flax, and what can be annoying when training models."
+    "Since JAX functions need to be written with certain constraints, there are situations where this can get annoying or difficult. A great overview of those, why they are needed, and most importantly, what to do about them, can be found in the original JAX tutorial [\ud83d\udd2a JAX - The Sharp Bits \ud83d\udd2a](https://jax.readthedocs.io/en/latest/notebooks/Common_Gotchas_in_JAX.html). In this final section of the tutorial, we want to visit a few of those points we have not explicitly discussed yet. Furthermore, we also focus on the combination with Flax, and what can be annoying when training models."
    ]
   },
   {
@@ -4281,8 +4267,8 @@
    "source": [
     "---\n",
     "\n",
-    "[![Star our repository](https://img.shields.io/static/v1.svg?logo=star&label=⭐&message=Star%20Our%20Repository&color=yellow)](https://github.com/phlippe/uvadlc_notebooks/)  If you found this tutorial helpful, consider ⭐-ing our repository.    \n",
-    "[![Ask questions](https://img.shields.io/static/v1.svg?logo=star&label=❔&message=Ask%20Questions&color=9cf)](https://github.com/phlippe/uvadlc_notebooks/issues)  For any questions, typos, or bugs that you found, please raise an issue on GitHub. \n",
+    "[![Star our repository](https://img.shields.io/static/v1.svg?logo=star&label=\u2b50&message=Star%20Our%20Repository&color=yellow)](https://github.com/phlippe/uvadlc_notebooks/)  If you found this tutorial helpful, consider \u2b50-ing our repository.    \n",
+    "[![Ask questions](https://img.shields.io/static/v1.svg?logo=star&label=\u2754&message=Ask%20Questions&color=9cf)](https://github.com/phlippe/uvadlc_notebooks/issues)  For any questions, typos, or bugs that you found, please raise an issue on GitHub. \n",
     "\n",
     "---"
    ]


### PR DESCRIPTION
- Replace flax.training.checkpoints.{save,restore}_checkpoint with orbax.checkpoint.StandardCheckpointer (PyTreeCheckpointer is deprecated).
- Bump flax/optax/jax pins in dl2023_jax_gpu.yml and add orbax-checkpoint so the env supports the new API.

Closes #79

## Tutorial/Bug description
<!-- If you add a new tutorial, describe the new tutorial you want to push to the repository. What topic is it dealing with? Which lecture is it relating to? -->
<!-- If you want to fix a bug, describe the bug and how you attempt to fix it. -->

## Checklist
- [ ] All packages are in the conda environment `dl2021`
- [ ] Pretrained models are automatically downloaded and stored at https://github.com/phlippe/saved_models / a pull request has been setup for this
- [ ] Notebook has badges for:
	- [ ] Filled notebook on github
	- [ ] Filled notebook on Colab
	- [ ] Saved models on github
	- [ ] YouTube recording
- [ ] The author names have been filled in
- [ ] The notebook has been added to the doc tree (`docs/index.rst`)
- [ ] All images of the notebook are included in the pull request
- [ ] The website was build locally once (do not commit the html files)

### How Has This Been Tested?
<!-- Make sure to have tested this notebook at least once for the conda environment, and once on GoogleColab -->
<!-- Further, the tutorial needs to be executable for both CPU and GPU systems -->
- [ ] Conda environment `dl2021`
- [ ] Local computer - CPU
- [ ] Local computer - GPU
- [ ] Google Colab - CPU
- [ ] Google Colab - GPU
- [ ] Lisa - GPU
